### PR TITLE
correct XCode code completion hints for ThrottleOptions and DebounceOptions

### DIFF
--- a/Sources/Throttler/Actor/Throttler.swift
+++ b/Sources/Throttler/Actor/Throttler.swift
@@ -9,14 +9,18 @@ import Foundation
 
 /// Options for debouncing an operation.
 public enum DebounceOptions {
-    case `default`         /// The default debounce behavior.
-    case runFirst          /// Run the operation immediately and debounce subsequent calls.
+    /// The default debounce behavior.
+    case `default`
+    /// Run the operation immediately and debounce subsequent calls.
+    case runFirst
 }
 
 /// Options for throttling an operation.
 public enum ThrottleOptions {
-    case `default`         /// The default throttle behavior.
-    case ensureLast        /// Guarantee that the last call is executed even if it's after the throttle time.
+    /// The default throttle behavior.
+    case `default`
+    /// Guarantee that the last call is executed even if it's after the throttle time.
+    case ensureLast
 }
 
 public enum ActorType {


### PR DESCRIPTION
Currently the wrong comment is shown when starting to type for `DebounceOptions` or `ThrottleOptions` as seen in the screenshot.
The `ensureLast` option is selected, but the text says "the default throttle behaviour", where it should actually say "Guarantee that the last call is executed even if it's after the throttle time.".
 
<img width="902" alt="Bildschirmfoto 2024-06-20 um 18 26 02" src="https://github.com/boraseoksoon/Throttler/assets/1710598/404537b7-8eab-4084-bd5e-c3748b075faa">

With the changes in this MR, the code completion overlay should show the correct comment.