### PR TITLE
fix: make throttler Swift 6 sendable-safe

### DIFF
--- a/Sources/Throttler/Actor/Throttler.swift
+++ b/Sources/Throttler/Actor/Throttler.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Options for debouncing an operation.
-public enum DebounceOptions {
+public enum DebounceOptions: Sendable {
     /// The default debounce behavior.
     case `default`
     /// Run the operation immediately and debounce subsequent calls.
@@ -16,18 +16,18 @@ public enum DebounceOptions {
 }
 
 /// Options for throttling an operation.
-public enum ThrottleOptions {
+public enum ThrottleOptions: Sendable {
     /// The default throttle behavior.
     case `default`
     /// Guarantee that the last call is executed even if it's after the throttle time.
     case ensureLast
 }
 
-public enum ActorType {
+public enum ActorType: Sendable {
     case currentActor
     case mainActor
     
-    @Sendable func run(_ operation: () -> Void) async {
+    func run(_ operation: @Sendable () -> Void) async {
         self == .mainActor ? await MainActor.run { operation() } : operation()
     }
 }
@@ -60,7 +60,7 @@ actor Throttler {
         identifier: String = "\(Thread.callStackSymbols)",
         by `actor`: ActorType = .mainActor,
         option: DebounceOptions = .default,
-        operation: @escaping () -> Void
+        operation: @Sendable @escaping () -> Void
     ) async {
         switch option {
         case .runFirst:
@@ -99,7 +99,7 @@ actor Throttler {
         identifier: String = "\(Thread.callStackSymbols)",
         by actor: ActorType = .mainActor,
         option: ThrottleOptions = .default,
-        operation: @escaping () -> Void
+        operation: @Sendable @escaping () -> Void
     ) async {
         let lastDate = lastAttemptDate[identifier]
         let lastTimeInterval = Date().timeIntervalSince(lastDate ?? .distantPast)
@@ -138,7 +138,7 @@ actor Throttler {
     func delay(
         _ duration: Duration = .seconds(1.0),
         by `actor`: ActorType = .mainActor,
-        operation: @escaping () -> Void
+        operation: @Sendable @escaping () -> Void
     ) async {
         try? await Task.sleep(for: duration)
         await actor.run(operation)

--- a/Sources/Throttler/debounce.swift
+++ b/Sources/Throttler/debounce.swift
@@ -54,7 +54,7 @@ public func debounce(
     identifier: String = "\(Thread.callStackSymbols)",
     by `actor`: ActorType = .mainActor,
     option: DebounceOptions = .default,
-    operation: @escaping () -> Void
+    operation: @Sendable @escaping () -> Void
 ) {
     Task {
         await throttler.debounce(

--- a/Sources/Throttler/delay.swift
+++ b/Sources/Throttler/delay.swift
@@ -36,7 +36,7 @@ import Foundation
 public func delay(
     _ duration: Duration = .seconds(1.0),
     by `actor`: ActorType = .mainActor,
-    operation: @escaping () -> Void
+    operation: @Sendable @escaping () -> Void
 ) {
     Task {
         await throttler.delay(

--- a/Sources/Throttler/throttle.swift
+++ b/Sources/Throttler/throttle.swift
@@ -55,7 +55,7 @@ public func throttle(
     identifier: String = "\(Thread.callStackSymbols)",
     by `actor`: ActorType = .mainActor,
     option: ThrottleOptions = .default,
-    operation: @escaping () -> Void
+    operation: @Sendable @escaping () -> Void
 ) {
     Task {
         await throttler.throttle(

--- a/Tests/ThrottlerTests/ThrottlerTests.swift
+++ b/Tests/ThrottlerTests/ThrottlerTests.swift
@@ -1,4 +1,64 @@
 import XCTest
 @testable import Throttler
 
-final class ThrottlerTests: XCTestCase {}
+actor Counter {
+    private var value = 0
+
+    func increment() {
+        value += 1
+    }
+
+    func currentValue() -> Int {
+        value
+    }
+}
+
+final class ThrottlerTests: XCTestCase {
+    func testDelayExecutesOperation() async {
+        let counter = Counter()
+
+        delay(.milliseconds(20), by: .mainActor) {
+            Task {
+                await counter.increment()
+            }
+        }
+
+        try? await Task.sleep(for: .milliseconds(120))
+        let count = await counter.currentValue()
+        XCTAssertEqual(count, 1)
+    }
+
+    func testDebounceCoalescesRapidCalls() async {
+        let counter = Counter()
+        let identifier = "debounce-test"
+
+        for _ in 0..<5 {
+            debounce(.milliseconds(40), identifier: identifier, by: .mainActor) {
+                Task {
+                    await counter.increment()
+                }
+            }
+        }
+
+        try? await Task.sleep(for: .milliseconds(180))
+        let count = await counter.currentValue()
+        XCTAssertEqual(count, 1)
+    }
+
+    func testThrottleEnsureLastExecutesAtLeastOnceForBurst() async {
+        let counter = Counter()
+        let identifier = "throttle-ensure-last-test"
+
+        for _ in 0..<5 {
+            throttle(.milliseconds(40), identifier: identifier, by: .mainActor, option: .ensureLast) {
+                Task {
+                    await counter.increment()
+                }
+            }
+        }
+
+        try? await Task.sleep(for: .milliseconds(250))
+        let count = await counter.currentValue()
+        XCTAssertGreaterThanOrEqual(count, 1)
+    }
+}


### PR DESCRIPTION
## Summary
- make `DebounceOptions`, `ThrottleOptions`, and `ActorType` conform to `Sendable`
- update internal/public throttle/debounce/delay closure parameters to `@Sendable`
- remove `@Sendable` from `ActorType.run` method declaration and keep sendability on the closure argument
- add regression tests for delay execution, debounce coalescing, and throttle ensureLast burst behavior

## Reproduction
Using Swift 6 strict concurrency mode on the current package:

```bash
swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors
```

Before this change, the build fails with Swift 6 sendability errors, including:
- `instance method of non-Sendable type 'ActorType' cannot be marked as '@Sendable'`
- multiple `sending ... risks causing data races` diagnostics in free-function wrappers

## Verification
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- `swift test`

Additionally validated from a real consumer app (`ControlZ`) by pinning to this branch: previous Throttler Swift 6 error no longer appears during package compilation.

Made with [Cursor](https://cursor.com)